### PR TITLE
make use of read replicas

### DIFF
--- a/http.go
+++ b/http.go
@@ -57,7 +57,7 @@ func httpVersion(w http.ResponseWriter, r *http.Request) {
 }
 
 func httpHeartbeat(w http.ResponseWriter, r *http.Request) {
-	_, err := sruntime.redis.Ping().Result()
+	_, err := sruntime.redis.ping().Result()
 	if err != nil {
 		log.Warnf(err.Error())
 		w.WriteHeader(http.StatusInternalServerError)

--- a/http_test.go
+++ b/http_test.go
@@ -318,7 +318,7 @@ func TestDecay(t *testing.T) {
 	}
 	buf, err := json.Marshal(r)
 	assert.Nil(t, err)
-	err = sruntime.redis.Set(r.IP, buf, 0).Err()
+	err = sruntime.redis.set(r.IP, buf, 0).Err()
 
 	// initial request with default (no) decay
 	recorder := httptest.NewRecorder()
@@ -454,7 +454,7 @@ func TestReviewedReset(t *testing.T) {
 	r.LastUpdated = time.Now().Add(-1 * (time.Second * 10)).UTC()
 	buf2, err = json.Marshal(r)
 	assert.Nil(t, err)
-	err = sruntime.redis.Set(r.IP, buf, 0).Err()
+	err = sruntime.redis.set(r.IP, buf, 0).Err()
 	assert.Nil(t, err)
 	recorder = httptest.NewRecorder()
 	req = httptest.NewRequest("GET", "/192.168.4.1", nil)

--- a/iprepd.yaml.sample
+++ b/iprepd.yaml.sample
@@ -3,7 +3,16 @@
 listen: 0.0.0.0:8080
 # Address/port for Redis connection
 redis:
+  # The primary Redis server.
   addr: 127.0.0.1:6379
+  # Support a Redis "cluster mode disabled" cluster with read replicas. Any read only replica
+  # instances can be added here.
+  #replicas:
+  #  - 127.0.0.1:7000
+  # Read, write, and dial connection timeouts in ms (defaults shown).
+  readtimeout: 50
+  writetimeout: 50
+  dialtimeout: 100
 auth:
   # Configure any Hawk credentials here. Each credential should be specified as a key/value
   # pair, where the key is the Hawk ID and the value is the secret.

--- a/iprepd_test.go
+++ b/iprepd_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func baseTest() error {
-	_, err := sruntime.redis.FlushAll().Result()
+	_, err := sruntime.redis.flushAll().Result()
 	if err != nil {
 		return err
 	}
@@ -41,13 +41,21 @@ func TestLoadSampleConfig(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	var err error
-	redisAddr := "127.0.0.1:6379"
+	var (
+		err  error
+		tcfg serverCfg
+	)
+	tcfg.Redis.Addr = "127.0.0.1:6379"
+	err = tcfg.validate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 	renv := os.Getenv("IPREPD_TEST_REDISADDR")
 	if renv != "" {
-		redisAddr = renv
+		tcfg.Redis.Addr = renv
 	}
-	sruntime.redis, err = initRedis(redisAddr)
+	sruntime.redis, err = newRedisLink(tcfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/redis.go
+++ b/redis.go
@@ -56,6 +56,9 @@ func newRedisLink(cfg serverCfg) (ret redisLink, err error) {
 		DialTimeout:  time.Millisecond * time.Duration(cfg.Redis.DialTimeout),
 	})
 	_, err = ret.ping().Result()
+	if err != nil {
+		return
+	}
 	ret.readClients = make([]*redis.Client, 0)
 	for _, x := range cfg.Redis.Replicas {
 		y := redis.NewClient(&redis.Options{

--- a/redis.go
+++ b/redis.go
@@ -22,13 +22,9 @@ func (r *redisLink) flushAll() *redis.StatusCmd {
 }
 
 func (r *redisLink) get(k string) (ret []byte, err error) {
-	readRot := make([]*redis.Client, len(r.readClients))
 	p := rand.Perm(len(r.readClients))
-	for a, b := range p {
-		readRot[b] = r.readClients[a]
-	}
-	for i := range readRot {
-		ret, err = readRot[i].Get(k).Bytes()
+	for _, i := range p {
+		ret, err = r.readClients[i].Get(k).Bytes()
 		if err == nil || (err != nil && err == redis.Nil) {
 			return
 		}

--- a/redis.go
+++ b/redis.go
@@ -1,0 +1,72 @@
+package iprepd
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/go-redis/redis"
+	log "github.com/sirupsen/logrus"
+)
+
+type redisLink struct {
+	master      *redis.Client
+	readClients []*redis.Client
+}
+
+func (r *redisLink) del(k ...string) *redis.IntCmd {
+	return r.master.Del(k...)
+}
+
+func (r *redisLink) flushAll() *redis.StatusCmd {
+	return r.master.FlushAll()
+}
+
+func (r *redisLink) get(k string) (ret []byte, err error) {
+	readRot := make([]*redis.Client, len(r.readClients))
+	p := rand.Perm(len(r.readClients))
+	for a, b := range p {
+		readRot[b] = r.readClients[a]
+	}
+	for i := range readRot {
+		ret, err = readRot[i].Get(k).Bytes()
+		if err == nil || (err != nil && err == redis.Nil) {
+			return
+		}
+		log.Error(err.Error())
+	}
+	// None of the read clients could satisfy the request, return the last
+	// error we have seen
+	return
+}
+
+func (r *redisLink) ping() *redis.StatusCmd {
+	return r.master.Ping()
+}
+
+func (r *redisLink) set(k string, v interface{}, e time.Duration) *redis.StatusCmd {
+	return r.master.Set(k, v, e)
+}
+
+func newRedisLink(cfg serverCfg) (ret redisLink, err error) {
+	ret.master = redis.NewClient(&redis.Options{
+		Addr:         cfg.Redis.Addr,
+		DB:           0,
+		ReadTimeout:  time.Millisecond * time.Duration(cfg.Redis.ReadTimeout),
+		WriteTimeout: time.Millisecond * time.Duration(cfg.Redis.WriteTimeout),
+		DialTimeout:  time.Millisecond * time.Duration(cfg.Redis.DialTimeout),
+	})
+	_, err = ret.ping().Result()
+	ret.readClients = make([]*redis.Client, 0)
+	for _, x := range cfg.Redis.Replicas {
+		y := redis.NewClient(&redis.Options{
+			Addr:        x,
+			DB:          0,
+			ReadTimeout: time.Millisecond * time.Duration(cfg.Redis.ReadTimeout),
+			DialTimeout: time.Millisecond * time.Duration(cfg.Redis.DialTimeout),
+		})
+		ret.readClients = append(ret.readClients, y)
+	}
+	// Also use the master for reads
+	ret.readClients = append(ret.readClients, ret.master)
+	return
+}

--- a/score.go
+++ b/score.go
@@ -44,7 +44,7 @@ func (r *Reputation) set() error {
 	if err != nil {
 		return err
 	}
-	return sruntime.redis.Set(r.IP, buf, time.Hour*24).Err()
+	return sruntime.redis.set(r.IP, buf, time.Hour*24).Err()
 }
 
 func (r *Reputation) applyViolation(v string) (found bool, err error) {
@@ -92,7 +92,7 @@ type Violation struct {
 }
 
 func repGet(ipstr string) (ret Reputation, err error) {
-	buf, err := sruntime.redis.Get(ipstr).Bytes()
+	buf, err := sruntime.redis.get(ipstr)
 	if err != nil {
 		return
 	}
@@ -105,6 +105,6 @@ func repGet(ipstr string) (ret Reputation, err error) {
 }
 
 func repDelete(ipstr string) (err error) {
-	_, err = sruntime.redis.Del(ipstr).Result()
+	_, err = sruntime.redis.del(ipstr).Result()
 	return
 }


### PR DESCRIPTION
Adds support to make use of Redis read replicas for reputation reads.
This is intended to be used in in an environment with a single master
node (used for reads/writes) that has X number of replica nodes (used by
iprepd only for reads). Reads are randomly distributed amongst
configured Redis cluster members.