### PR TITLE
dockerfile: specify uid/gid 10001 by cloudops convention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.10.2
 
-RUN groupadd app && useradd -g app -d /app -m app
+RUN mkdir /app && \
+    chown 10001:10001 /app && \
+    groupadd --gid 10001 app && \
+    useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
 
 ADD . /go/src/go.mozilla.org/iprepd
 RUN mkdir -p /app/bin && \


### PR DESCRIPTION
we have a general convention of creating app users with uid 10001. files volume mounted into the docker container have to have corresponding ownership, and when the user is created in the way it is now, it conflicted with an existing user on our instances.