### PR TITLE
Create docker compose test and run configurations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ jobs:
           command: ./write_version_json.sh
       - run:
           name: Build containers
-          command: docker-compose build
+          command: make build
       - run:
           name: Run tests
-          command: docker-compose run test
+          command: make test
       - run:
          name: Push to Docker Hub
          command: |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+build: compose/docker-compose.base.yml
+	docker-compose -f compose/docker-compose.base.yml build
+
+run: compose/docker-compose.run.yml
+	CONFIG_VOLUME=$(shell pwd) docker-compose -f compose/docker-compose.base.yml -f compose/docker-compose.run.yml up
+
+test: compose/docker-compose.test.yml
+	docker-compose -f compose/docker-compose.base.yml -f compose/docker-compose.test.yml run iprepd
+
+
+.PHONY: build run test

--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -7,15 +7,14 @@ services:
     ports:
       - "6379:6379"
 
-  test:
+  iprepd:
     container_name: iprepd_app
     image: iprepd:build
     build:
-      context: .
+      context: ../.
     environment:
       - IPREPD_TEST_REDISADDR=redis:6379
     links:
       - redis
     ports:
       - "8080:8080"
-    command: bash -c 'cd /go/src/go.mozilla.org/iprepd && go test -v'

--- a/compose/docker-compose.run.yml
+++ b/compose/docker-compose.run.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+  iprepd:
+    volumes:
+      - '$CONFIG_VOLUME:/app/config/'
+    command: bash -c '/app/bin/iprepd -c /app/config/iprepd.yaml'

--- a/compose/docker-compose.test.yml
+++ b/compose/docker-compose.test.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+services:
+  iprepd:
+    command: bash -c 'cd /go/src/go.mozilla.org/iprepd && go test -v'


### PR DESCRIPTION
Now if you create an `iprepd.yaml`, you can run `make run` and have a running local instance of iprepd.

As well, instead of using `docker-compose` directly, there is `make build` and `make test`