### PR TITLE
Endpoint to dump reputation entires

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ error will be logged.
 ]
 ```
 
+#### GET /dump
+
+Returns all reputation entries.
+
+**Note: This makes use of the [KEYS](https://redis.io/commands/keys) redis command, which is known to be very slow. Use with care.**
+
+##### Response body
+
+```json
+[
+  {"ip": "10.0.0.1", "reputation": 75, "reviewed": false, "lastupdated": "2018-04-23T18:25:43.511Z"},
+  {"ip": "10.0.0.2", "reputation": 50, "reviewed": false, "lastupdated": "2018-04-23T18:31:27.457Z"},
+  {"ip": "10.0.20.2", "reputation": 25, "reviewed": false, "lastupdated": "2018-04-23T17:22:42.230Z"},
+]
+```
+
+
 #### GET /\_\_heartbeat\_\_
 
 Service heartbeat endpoint.

--- a/redis.go
+++ b/redis.go
@@ -13,6 +13,10 @@ type redisLink struct {
 	readClients []*redis.Client
 }
 
+func (r *redisLink) keys(pattern string) *redis.StringSliceCmd {
+	return r.master.Keys(pattern)
+}
+
 func (r *redisLink) del(k ...string) *redis.IntCmd {
 	return r.master.Del(k...)
 }

--- a/score.go
+++ b/score.go
@@ -108,3 +108,25 @@ func repDelete(ipstr string) (err error) {
 	_, err = sruntime.redis.del(ipstr).Result()
 	return
 }
+
+func repDump() (ret []Reputation, err error) {
+	keys, err := sruntime.redis.keys("*").Result()
+	if err != nil {
+		return
+	}
+
+	for _, ip := range keys {
+		buf, err := sruntime.redis.get(ip)
+		if err != nil {
+			return ret, err
+		}
+		reputation := Reputation{}
+		err = json.Unmarshal(buf, &reputation)
+		if err != nil {
+			return ret, err
+		}
+		ret = append(ret, reputation)
+	}
+
+	return
+}


### PR DESCRIPTION
`/dump` will return an array with all reputation entries.

Fixes #8

```
$ http http://localhost:8080/dump Authorization:"APIKey ..."
HTTP/1.1 200 OK
...

[
    {
        "ip": "192.168.4.1",
        "lastupdated": "2019-01-22T23:32:01.136021124Z",
        "reputation": 100,
        "reviewed": false
    },
    {
        "ip": "127.0.0.1",
        "lastupdated": "2019-01-22T23:32:29.137167819Z",
        "reputation": 100,
        "reviewed": false
    },
    {
        "ip": "192.168.0.1",
        "lastupdated": "2019-01-22T23:32:01.134266058Z",
        "reputation": 50,
        "reviewed": false
    },
    {
        "ip": "10.0.0.1",
        "lastupdated": "2019-01-22T23:32:01.13463148Z",
        "reputation": 25,
        "reviewed": false
    }
]
```