### PR TITLE
In addition to IP addresses, support tracking other types of objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ to decay back to 100. If this setting is not included, the reputation will begin
 immediately. If the violation is being applied to an existing entry, the `suppress_recovery` field
 will only be applied if the existing entry has no current recovery suppression, or the specified
 recovery suppression time frame would result in a time in the future beyond which the entry
-currently has. If `suppress_recovery` is included it must be less than `259200` (72 hours).
+currently has. If `suppress_recovery` is included it must be less than `1209600` (14 days).
 
 ##### Request body
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # iprepd
 
-iprepd is a centralized IP reputation daemon that can be used to store reputation information
-for IP addresses and retrieve reputation scores for addresses.
+iprepd is a centralized reputation daemon that can be used to store reputation information
+for various objects such as IP addresses and retrieve reputation scores for the objects.
+
+The project initially focused on managing reputation information for only IP addresses, but
+has since been expanded to allow reputation tracking for other types of values such as account
+names or email addresses.
 
 The daemon provides an HTTP API for requests, and uses a Redis server as the backend storage
 mechanism. Multiple instances of the daemon can be deployed using the same Redis backend.
@@ -28,6 +32,154 @@ docker run -ti --rm -v `pwd`/iprepd.yaml:/app/iprepd.yaml mozilla/iprepd:latest
 ```
 
 ## API
+
+### Endpoints
+
+#### GET /type/ip/10.0.0.1
+
+Request the reputation for an object of a given type. Responds with 200 and a JSON
+document describing the reputation if found. Responds with a 404 if the object is
+unknown to iprepd, or is in the exceptions list.
+
+The current supported object types are `ip` for an IP address and `email` for an
+email address.
+
+The response body may include a `decayafter` element if the reputation for the address was changed
+with a recovery suppression applied. If the timestamp is present, it indicates the time after which
+the reputation for the address will begin to recover.
+
+##### Response body
+
+```json
+{
+	"object": "10.0.0.1",
+        "type": "ip",
+	"reputation": 75,
+	"reviewed": false,
+	"lastupdated": "2018-04-23T18:25:43.511Z"
+}
+```
+
+#### DELETE /type/ip/10.0.0.1
+
+Deletes the reputation entry for the requested object of the specified type.
+
+#### PUT /type/ip/10.0.0.1
+
+Sets a reputation score for the specified object of the specified type. A reputation JSON
+document must be provided with the request body. The `reputation` field must be provided
+in the document. The reviewed field can be included and set to true to toggle the reviewed
+field for a given reputation entry.
+
+Note that if the reputation decays back to 100, if the reviewed field is set on the entry it will
+toggle back to false.
+
+The reputation will begin to decay back to 100 immediately for the address based on the decay
+settings in the configuration file. If it is desired that the reputation should not decay for a
+period of time, the `decayafter` field can be set with a timestamp to indicate when the reputation
+decay logic should begin to be applied for the entry.
+
+##### Request body
+
+```json
+{
+	"object": "10.0.0.1",
+        "type": "ip",
+	"reputation": 75
+}
+```
+
+#### PUT /violations/type/ip/10.0.0.1
+
+Applies a violation penalty to the specified object of the specified type.
+
+If an unknown violation penalty is submitted, this endpoint will still return 200, but the
+error will be logged.
+
+If desired, `suppress_recovery` can be included in the request body and set to an integer which
+indicates the number of seconds that must elapse before the reputation for this entry will begin
+to decay back to 100. If this setting is not included, the reputation will begin to decay
+immediately. If the violation is being applied to an existing entry, the `suppress_recovery` field
+will only be applied if the existing entry has no current recovery suppression, or the specified
+recovery suppression time frame would result in a time in the future beyond which the entry
+currently has. If `suppress_recovery` is included it must be less than `259200` (72 hours).
+
+##### Request body
+
+```json
+{
+	"object": "10.0.0.1",
+        "type": "ip",
+	"violation": "violation1"
+}
+```
+
+#### PUT /violations/type/ip
+
+Applies a violation penalty to a multiple objects of a given type.
+
+If an unknown violation penalty is submitted, this endpoint will still return 200, but the
+error will be logged.
+
+##### Request body
+
+```json
+[
+	{"object": "10.0.0.1", "type": "ip", "violation": "violation1"},
+	{"object": "10.0.0.2", "type": "ip", "violation": "violation1"},
+	{"object": "10.0.0.3", "type": "ip", "violation": "violation2"}
+]
+
+#### GET /violations
+
+Returns violations configured in iprepd in a JSON document.
+
+##### Response body
+
+```json
+[
+	{"name": "violation1", "penalty": 5, "decreaselimit": 50},
+	{"name": "violation2", "penalty": 25, "decreaselimit": 0},
+]
+```
+
+#### GET /dump
+
+Returns all reputation entries.
+
+**Note: This makes use of the [KEYS](https://redis.io/commands/keys) redis command, which is known to be very slow. Use with care.**
+
+##### Response body
+
+```json
+[
+  {"ip": "10.0.0.1", "reputation": 75, "reviewed": false, "lastupdated": "2018-04-23T18:25:43.511Z"},
+  {"ip": "10.0.0.2", "reputation": 50, "reviewed": false, "lastupdated": "2018-04-23T18:31:27.457Z"},
+  {"ip": "10.0.20.2", "reputation": 25, "reviewed": false, "lastupdated": "2018-04-23T17:22:42.230Z"},
+]
+```
+
+
+#### GET /\_\_heartbeat\_\_
+
+Service heartbeat endpoint.
+
+#### GET /\_\_lbheartbeat\_\_
+
+Service heartbeat endpoint.
+
+#### GET /\_\_version\_\_
+
+Return version data.
+
+### Legacy endpoints
+
+The initial version of iprepd focused purely on reputation management for IP addresses.
+Requests to the legacy endpoints deal only with IP addresses, and are intended to maintain
+compatibility with older clients.
+
+Requests to the legacy endpoints are essentially the same thing as making a request to the
+standard endpoints with a type set to `ip`.
 
 #### GET /10.0.0.1
 
@@ -77,19 +229,6 @@ decay logic should begin to be applied for the entry.
 }
 ```
 
-#### GET /violations
-
-Returns violations configured in iprepd in a JSON document.
-
-##### Response body
-
-```json
-[
-	{"name": "violation1", "penalty": 5, "decreaselimit": 50},
-	{"name": "violation2", "penalty": 25, "decreaselimit": 0},
-]
-```
-
 #### PUT /violations/10.0.0.1
 
 Applies a violation penalty to an IP address.
@@ -130,35 +269,6 @@ error will be logged.
 	{"ip": "10.0.0.3", "violation": "violation2"}
 ]
 ```
-
-#### GET /dump
-
-Returns all reputation entries.
-
-**Note: This makes use of the [KEYS](https://redis.io/commands/keys) redis command, which is known to be very slow. Use with care.**
-
-##### Response body
-
-```json
-[
-  {"ip": "10.0.0.1", "reputation": 75, "reviewed": false, "lastupdated": "2018-04-23T18:25:43.511Z"},
-  {"ip": "10.0.0.2", "reputation": 50, "reviewed": false, "lastupdated": "2018-04-23T18:31:27.457Z"},
-  {"ip": "10.0.20.2", "reputation": 25, "reviewed": false, "lastupdated": "2018-04-23T17:22:42.230Z"},
-]
-```
-
-
-#### GET /\_\_heartbeat\_\_
-
-Service heartbeat endpoint.
-
-#### GET /\_\_lbheartbeat\_\_
-
-Service heartbeat endpoint.
-
-#### GET /\_\_version\_\_
-
-Return version data.
 
 ## Acknowledgements
 

--- a/http.go
+++ b/http.go
@@ -64,7 +64,7 @@ func (v *ViolationRequest) Validate() error {
 	if v.Type == "" {
 		return fmt.Errorf("violation request missing required field type")
 	}
-	if v.SuppressRecovery > 259200 {
+	if v.SuppressRecovery > 1209600 {
 		return fmt.Errorf("invalid suppress recovery value %v", v.SuppressRecovery)
 	}
 	return nil

--- a/http.go
+++ b/http.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"time"
 
@@ -14,16 +13,57 @@ import (
 )
 
 // ViolationRequest represents the structure used to apply a violation to a given
-// IP address. This structure is used as the basis for unmarshaling requests to
+// object. This structure is used as the basis for unmarshaling requests to
 // violation handlers in the API.
 type ViolationRequest struct {
-	IP               string `json:"ip"`
-	Violation        string `json:"violation"`
-	SuppressRecovery int    `json:"suppress_recovery,omitempty"`
+	// The violation name to be applied
+	Violation string `json:"violation,omitempty"`
+
+	// The object the violation should be applied to.
+	Object string `json:"object,omitempty"`
+
+	// The type of object (e.g., ip).
+	Type string `json:"type,omitempty"`
+
+	// An optional recovery suppression value in seconds. If set, it indicates the
+	// number of seconds which must pass before the reputation for the object will
+	// begin to recover.
+	SuppressRecovery int `json:"suppress_recovery,omitempty"`
+
+	// The IP field supports reverse compatibility with older clients. It is essentially
+	// the same thing as passing an IP address in the object field, with a type set to
+	// ip.
+	IP string `json:"ip,omitempty"`
+}
+
+// Fixup is used to convert legacy format violations
+func (v *ViolationRequest) Fixup(typestr string) {
+	// Only apply fixup to ip type requests
+	if typestr != "ip" {
+		return
+	}
+	// If the type field is not set, set it to the type specified in the request
+	// path
+	if v.Type == "" {
+		v.Type = typestr
+	}
+	// If object is not set but the IP field is set, use that as the object
+	if v.Object == "" && v.IP != "" {
+		v.Object = v.IP
+	}
 }
 
 // Validate performs validation of a ViolationRequest type
 func (v *ViolationRequest) Validate() error {
+	if v.Violation == "" {
+		return fmt.Errorf("violation request missing required field violation")
+	}
+	if v.Object == "" {
+		return fmt.Errorf("violation request missing required field object")
+	}
+	if v.Type == "" {
+		return fmt.Errorf("violation request missing required field type")
+	}
 	if v.SuppressRecovery > 259200 {
 		return fmt.Errorf("invalid suppress recovery value %v", v.SuppressRecovery)
 	}
@@ -48,25 +88,72 @@ func mwHandler(h http.Handler) http.Handler {
 func newRouter() *mux.Router {
 	r := mux.NewRouter().StrictSlash(true)
 
-	// unauth endpoints
+	// Unauthenticated endpoints
 	r.HandleFunc("/__lbheartbeat__", httpHeartbeat).Methods("GET")
 	r.HandleFunc("/__heartbeat__", httpHeartbeat).Methods("GET")
 	r.HandleFunc("/__version__", httpVersion).Methods("GET")
 
-	// auth endpoints
+	// Legacy IP reputation endpoints
+	//
+	// To maintain compatibility with previous API versions, wrap legacy API
+	// calls to add the type field and route to the correct handler
+	r.HandleFunc("/{value:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}}",
+		auth(wrapLegacyIpRequest(httpGetReputation))).Methods("GET")
+	r.HandleFunc("/{value:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}}",
+		auth(wrapLegacyIpRequest(httpPutReputation))).Methods("PUT")
+	r.HandleFunc("/{value:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}}",
+		auth(wrapLegacyIpRequest(httpDeleteReputation))).Methods("DELETE")
+	r.HandleFunc("/violations/{value:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}}",
+		auth(wrapLegacyIpRequest(httpPutViolation))).Methods("PUT")
+	r.HandleFunc("/violations", auth(wrapLegacyIpRequest(httpPutViolations))).Methods("PUT")
+
 	r.HandleFunc("/violations", auth(httpGetViolations)).Methods("GET")
-	r.HandleFunc("/{ip:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}}", auth(httpGetReputation)).Methods("GET")
-	r.HandleFunc("/{ip:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}}", auth(httpPutReputation)).Methods("PUT")
-	r.HandleFunc("/{ip:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}}", auth(httpDeleteReputation)).Methods("DELETE")
-	r.HandleFunc("/violations/{ip:(?:[0-9]{1,3}\\.){3}[0-9]{1,3}}", auth(httpPutViolation)).Methods("PUT")
-	r.HandleFunc("/violations", auth(httpPutViolations)).Methods("PUT")
 	r.HandleFunc("/dump", auth(httpGetAllReputation)).Methods("GET")
+	r.HandleFunc("/type/{type:[a-z]{1,12}}/{value}", auth(httpGetReputation)).Methods("GET")
+	r.HandleFunc("/type/{type:[a-z]{1,12}}/{value}", auth(httpPutReputation)).Methods("PUT")
+	r.HandleFunc("/type/{type:[a-z]{1,12}}/{value}", auth(httpDeleteReputation)).Methods("DELETE")
+	r.HandleFunc("/violations/type/{type:[a-z]{1,12}}/{value}", auth(httpPutViolation)).Methods("PUT")
+	r.HandleFunc("/violations/type/{type:[a-z]{1,12}}", auth(httpPutViolations)).Methods("PUT")
 
 	return r
 }
 
 func startAPI() error {
 	return http.ListenAndServe(sruntime.cfg.Listen, mwHandler(newRouter()))
+}
+
+func wrapLegacyIpRequest(rf func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m := mux.Vars(r)
+		m["type"] = "ip"
+		mux.SetURLVars(r, m)
+		rf(w, r)
+	}
+}
+
+func hasValidType(r *http.Request) error {
+	t := mux.Vars(r)["type"]
+	_, ok := validators[t]
+	if !ok {
+		return fmt.Errorf("type %v is invalid", t)
+	}
+	return nil
+}
+
+func verifyTypeAndValue(r *http.Request) (t string, v string, err error) {
+	err = hasValidType(r)
+	if err != nil {
+		return t, v, err
+	}
+	t = mux.Vars(r)["type"]
+	if t == "" {
+		return t, v, fmt.Errorf("type was not set")
+	}
+	v = mux.Vars(r)["value"]
+	if v == "" {
+		return t, v, fmt.Errorf("value was not set")
+	}
+	return t, v, validateType(t, v)
 }
 
 func httpVersion(w http.ResponseWriter, r *http.Request) {
@@ -119,16 +206,21 @@ func httpGetReputation(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		sruntime.statsd.Timing("http.get_reputation.timing", time.Since(s))
 	}()
-	ipstr := mux.Vars(r)["ip"]
-	if net.ParseIP(ipstr) == nil {
+	typestr, valstr, err := verifyTypeAndValue(r)
+	if err != nil {
+		log.Warnf(err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	if isException(ipstr) {
-		w.WriteHeader(http.StatusNotFound)
-		return
+	// If the request is for an IP type object, consult the exception list. Currently
+	// exceptions only apply to IP objects.
+	if typestr == "ip" {
+		if isException(valstr) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 	}
-	rep, err := repGet(ipstr)
+	rep, err := repGet(typestr, valstr)
 	if err != nil {
 		if err == redis.Nil {
 			w.WriteHeader(http.StatusNotFound)
@@ -149,8 +241,8 @@ func httpGetReputation(w http.ResponseWriter, r *http.Request) {
 }
 
 func httpPutReputation(w http.ResponseWriter, r *http.Request) {
-	ipstr := mux.Vars(r)["ip"]
-	if net.ParseIP(ipstr) == nil {
+	typestr, valstr, err := verifyTypeAndValue(r)
+	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -167,8 +259,9 @@ func httpPutReputation(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	// Force IP field to match value specified in request path
-	rep.IP = ipstr
+	// Force object field and type to match value specified in request path
+	rep.Object = valstr
+	rep.Type = typestr
 	err = rep.Validate()
 	if err != nil {
 		log.Warnf(err.Error())
@@ -181,20 +274,25 @@ func httpPutReputation(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	exc := false
+	if rep.Type == "ip" {
+		exc = isException(rep.Object)
+	}
 	log.WithFields(log.Fields{
-		"ip":         rep.IP,
+		"object":     rep.Object,
+		"type":       rep.Type,
 		"reputation": rep.Reputation,
-		"exception":  isException(rep.IP),
+		"exception":  exc,
 	}).Info("reputation set")
 }
 
 func httpDeleteReputation(w http.ResponseWriter, r *http.Request) {
-	ipstr := mux.Vars(r)["ip"]
-	if net.ParseIP(ipstr) == nil {
+	typestr, valstr, err := verifyTypeAndValue(r)
+	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	err := repDelete(ipstr)
+	err = repDelete(typestr, valstr)
 	if err != nil {
 		log.Warnf(err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
@@ -203,8 +301,8 @@ func httpDeleteReputation(w http.ResponseWriter, r *http.Request) {
 }
 
 func httpPutViolation(w http.ResponseWriter, r *http.Request) {
-	ipstr := mux.Vars(r)["ip"]
-	if net.ParseIP(ipstr) == nil {
+	typestr, valstr, err := verifyTypeAndValue(r)
+	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -221,11 +319,20 @@ func httpPutViolation(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	v.IP = ipstr
-	httpPutViolationsInner(w, r, []ViolationRequest{v})
+	// Force object field and type to match value specified in request path
+	v.Object = valstr
+	v.Type = typestr
+	httpPutViolationsInner(w, r, typestr, []ViolationRequest{v})
 }
 
 func httpPutViolations(w http.ResponseWriter, r *http.Request) {
+	// We only have a type to verify here
+	err := hasValidType(r)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	typestr := mux.Vars(r)["type"]
 	buf, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Warnf(err.Error())
@@ -239,11 +346,14 @@ func httpPutViolations(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	httpPutViolationsInner(w, r, vs)
+	httpPutViolationsInner(w, r, typestr, vs)
 }
 
-func httpPutViolationsInner(w http.ResponseWriter, r *http.Request, vs []ViolationRequest) {
+func httpPutViolationsInner(w http.ResponseWriter, r *http.Request, typestr string, vs []ViolationRequest) {
 	for _, v := range vs {
+		v.Fixup(typestr)
+		// Force type field to match value specified in request path
+		v.Type = typestr
 		err := v.Validate()
 		if err != nil {
 			log.Warnf(err.Error())
@@ -251,10 +361,21 @@ func httpPutViolationsInner(w http.ResponseWriter, r *http.Request, vs []Violati
 			return
 		}
 
-		rep, err := repGet(v.IP)
+		rep, err := repGet(typestr, v.Object)
 		if err == redis.Nil {
-			rep = Reputation{IP: v.IP, Reputation: 100}
+			rep = Reputation{
+				Object:     v.Object,
+				Type:       typestr,
+				Reputation: 100,
+			}
 		} else if err != nil {
+			log.Warnf(err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		err = rep.Validate()
+		if err != nil {
 			log.Warnf(err.Error())
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -279,7 +400,8 @@ func httpPutViolationsInner(w http.ResponseWriter, r *http.Request, vs []Violati
 				// just log it
 				log.WithFields(log.Fields{
 					"violation": v.Violation,
-					"ip":        v.IP,
+					"object":    v.Object,
+					"type":      v.Type,
 				}).Warn("ignoring unknown violation")
 				continue
 			}
@@ -293,13 +415,18 @@ func httpPutViolationsInner(w http.ResponseWriter, r *http.Request, vs []Violati
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+		exc := false
+		if rep.Type == "ip" {
+			exc = isException(rep.Object)
+		}
 		log.WithFields(log.Fields{
 			"violation":           v.Violation,
-			"ip":                  rep.IP,
+			"object":              rep.Object,
+			"type":                rep.Type,
 			"reputation":          rep.Reputation,
 			"decay_after":         rep.DecayAfter,
 			"original_reputation": origRep,
-			"exception":           isException(rep.IP),
+			"exception":           exc,
 		}).Info("violation applied")
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -51,7 +51,7 @@ func TestHandlers(t *testing.T) {
 
 	// request reputation for a stored ip
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	res = recorder.Result()
@@ -61,9 +61,469 @@ func TestHandlers(t *testing.T) {
 	var r Reputation
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
+	assert.Equal(t, "192.168.0.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 50, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+
+	// request reputation for stored legacy format entry
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/254.254.254.254", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "254.254.254.254", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 40, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+	// IP field should also be set
+	assert.Equal(t, "254.254.254.254", r.IP)
+
+	// request reputation for an unknown ip
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.2", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	// request reputation for an unknown email
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/picard@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	// request reputation for invalid ip, should get a 400 as it will not pass
+	// the type validator
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/255.2555.255.255", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	// request reputation for invalid email, should get a 400 as it will not pass
+	// the type validator
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/worf@@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	// request reputation for invalid type
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/something/string", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	// store reputation for an ip
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.2.20", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+	recorder = httptest.NewRecorder()
+	buf2 := "{\"object\": \"192.168.2.20\", \"type\": \"ip\", \"reputation\": 25}"
+	req = httptest.NewRequest("PUT", "/type/ip/192.168.2.20", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.2.20", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "192.168.2.20", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 25, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+
+	// store reputation for an email address
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/riker@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"riker@mozilla.com\", \"type\": \"email\", \"reputation\": 50}"
+	req = httptest.NewRequest("PUT", "/type/email/riker@mozilla.com", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/riker@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "riker@mozilla.com", r.Object)
+	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, 50, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+
+	// try to store invalid reputation score
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"192.168.2.20\", \"type\": \"ip\", \"reputation\": 500}"
+	req = httptest.NewRequest("PUT", "/type/ip/192.168.2.20", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	// try to store invalid reputation type
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"string\", \"type\": \"something\", \"reputation\": 50}"
+	req = httptest.NewRequest("PUT", "/type/something/string", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	// dump reputation
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/dump", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	var reputations []Reputation
+	err = json.Unmarshal(buf, &reputations)
+	assert.Nil(t, err)
+	assert.Equal(t, 5, len(reputations))
+	c := 0
+	for _, rep := range reputations {
+		if rep.Object == "192.168.2.20" {
+			c += 1
+			assert.Equal(t, "192.168.2.20", rep.Object)
+			assert.Equal(t, "ip", rep.Type)
+			assert.Equal(t, 25, rep.Reputation)
+		}
+		if rep.Object == "192.168.0.1" {
+			c += 1
+			assert.Equal(t, "192.168.0.1", rep.Object)
+			assert.Equal(t, "ip", rep.Type)
+			assert.Equal(t, 50, rep.Reputation)
+		}
+		if rep.Object == "riker@mozilla.com" {
+			c += 1
+			assert.Equal(t, "riker@mozilla.com", rep.Object)
+			assert.Equal(t, "email", rep.Type)
+			assert.Equal(t, 50, rep.Reputation)
+		}
+		if rep.IP == "254.254.254.254" {
+			c += 1
+			assert.Equal(t, "254.254.254.254", rep.IP)
+			assert.Equal(t, "", rep.Object)
+			assert.Equal(t, "", rep.Type)
+		}
+		assert.Equal(t, false, rep.Reviewed)
+	}
+	assert.Equal(t, 4, c)
+
+	// delete entry
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("DELETE", "/type/ip/192.168.2.20", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.2.20", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	// create and delete an email entry
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/janeway@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"janeway@mozilla.com\", \"type\": \"email\", \"reputation\": 50}"
+	req = httptest.NewRequest("PUT", "/type/email/janeway@mozilla.com", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/janeway@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "janeway@mozilla.com", r.Object)
+	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, 50, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("DELETE", "/type/email/janeway@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/janeway@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	// put violation for an ip
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"192.168.3.1\", \"type\": \"ip\", \"violation\": \"violation1\"}"
+	req = httptest.NewRequest("PUT", "/violations/type/ip/192.168.3.1", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.3.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "192.168.3.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 95, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+	assert.True(t, r.DecayAfter.IsZero())
+
+	// put violation for an email
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"riker@mozilla.com\", \"type\": \"email\", \"violation\": \"violation1\"}"
+	req = httptest.NewRequest("PUT", "/violations/type/email/riker@mozilla.com", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/riker@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "riker@mozilla.com", r.Object)
+	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, 45, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+	assert.True(t, r.DecayAfter.IsZero())
+
+	// put violations for ip
+	recorder = httptest.NewRecorder()
+	buf2 = "[{\"object\": \"192.168.4.1\", \"type\": \"ip\", \"violation\": \"violation1\"}," +
+		"{\"object\": \"192.168.5.1\", \"type\": \"ip\", \"violation\": \"violation2\"}]"
+	req = httptest.NewRequest("PUT", "/violations/type/ip", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.4.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "192.168.4.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 95, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.5.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "192.168.5.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 50, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+
+	// put violations for email
+	recorder = httptest.NewRecorder()
+	buf2 = "[{\"object\": \"riker@mozilla.com\", \"type\": \"email\", \"violation\": \"violation1\"}," +
+		"{\"object\": \"troi@mozilla.com\", \"type\": \"email\", \"violation\": \"violation2\"}]"
+	req = httptest.NewRequest("PUT", "/violations/type/email", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/riker@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "riker@mozilla.com", r.Object)
+	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, 40, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/email/troi@mozilla.com", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "troi@mozilla.com", r.Object)
+	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, 50, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+
+	// put violation with recovery suppression
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"192.168.6.1\", \"type\": \"ip\", \"violation\": \"violation1\", " +
+		"\"suppress_recovery\":120}"
+	dt := time.Now().UTC().Add(time.Second * time.Duration(120))
+	req = httptest.NewRequest("PUT", "/violations/type/ip/192.168.6.1", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.6.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "192.168.6.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 95, r.Reputation)
+	assert.InDelta(t, dt.Unix(), r.DecayAfter.Unix(), 5)
+
+	// ensure recovery suppression remains after a subsequent violation without suppression indicated
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"192.168.6.1\", \"type\": \"ip\", \"violation\": \"violation1\"}"
+	req = httptest.NewRequest("PUT", "/violations/type/ip/192.168.6.1", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.6.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "192.168.6.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 90, r.Reputation)
+	assert.InDelta(t, dt.Unix(), r.DecayAfter.Unix(), 5)
+
+	// apply suppression that is less than what is currently configured, should not change entry
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"192.168.6.1\", \"type\": \"ip\", \"violation\": \"violation1\", " +
+		"\"suppress_recovery\":5}"
+	req = httptest.NewRequest("PUT", "/violations/type/ip/192.168.6.1", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.6.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "192.168.6.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 85, r.Reputation)
+	assert.InDelta(t, dt.Unix(), r.DecayAfter.Unix(), 5)
+
+	// apply suppression that is greater than what is currently configured but with a bad violation
+	// name, should not change entry
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"192.168.6.1\", \"type\": \"ip\", \"violation\": \"unknown_violation5\"," +
+		" \"suppress_recovery\":99999}"
+	req = httptest.NewRequest("PUT", "/violations/type/ip/192.168.6.1", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.6.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "192.168.6.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, 85, r.Reputation)
+	assert.InDelta(t, dt.Unix(), r.DecayAfter.Unix(), 5)
+
+	// put violation with bad recovery suppression
+	recorder = httptest.NewRecorder()
+	buf2 = "{\"object\": \"192.168.7.1\", \"type\": \"ip\", \"violation\": \"violation1\", " +
+		"\"suppress_recovery\":999999999}"
+	req = httptest.NewRequest("PUT", "/violations/type/ip/192.168.7.1", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+func TestHandlersLegacy(t *testing.T) {
+	assert.Nil(t, baseTest())
+	sruntime.cfg.Auth.DisableAuth = true
+	h := mwHandler(newRouter())
+
+	// request reputation for a stored ip
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/192.168.0.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res := recorder.Result()
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	buf, err := ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	var r Reputation
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
 	assert.Equal(t, "192.168.0.1", r.IP)
 	assert.Equal(t, 50, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
+	// The object and type fields should also be set on request to the legacy endpoint
+	// here
+	assert.Equal(t, "192.168.0.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
+
+	// request reputation for a stored legacy format entry
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/254.254.254.254", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	res = recorder.Result()
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	buf, err = ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
+	err = json.Unmarshal(buf, &r)
+	assert.Nil(t, err)
+	assert.Equal(t, "254.254.254.254", r.IP)
+	assert.Equal(t, 40, r.Reputation)
+	assert.Equal(t, false, r.Reviewed)
+	// The object and type fields should also be set on request to the legacy endpoint
+	// here
+	assert.Equal(t, "254.254.254.254", r.Object)
+	assert.Equal(t, "ip", r.Type)
 
 	// request reputation for an unknown ip
 	recorder = httptest.NewRecorder()
@@ -101,6 +561,8 @@ func TestHandlers(t *testing.T) {
 	assert.Equal(t, "192.168.2.20", r.IP)
 	assert.Equal(t, 25, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
+	assert.Equal(t, "192.168.2.20", r.Object)
+	assert.Equal(t, "ip", r.Type)
 
 	// try to store invalid reputation score
 	recorder = httptest.NewRecorder()
@@ -109,35 +571,6 @@ func TestHandlers(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
-
-	// dump reputation
-	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/dump", nil)
-	h.ServeHTTP(recorder, req)
-	assert.Equal(t, http.StatusOK, recorder.Code)
-	res = recorder.Result()
-	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
-	buf, err = ioutil.ReadAll(res.Body)
-	assert.Nil(t, err)
-	var reputations []Reputation
-	err = json.Unmarshal(buf, &reputations)
-	assert.Nil(t, err)
-	assert.Equal(t, 3, len(reputations))
-	c := 0
-	for _, rep := range reputations {
-		if rep.IP == "192.168.2.20" {
-			c += 1
-			assert.Equal(t, "192.168.2.20", rep.IP)
-			assert.Equal(t, 25, rep.Reputation)
-		}
-		if rep.IP == "192.168.0.1" {
-			c += 1
-			assert.Equal(t, "192.168.0.1", rep.IP)
-			assert.Equal(t, 50, rep.Reputation)
-		}
-		assert.Equal(t, false, rep.Reviewed)
-	}
-	assert.Equal(t, 2, c)
 
 	// delete entry
 	recorder = httptest.NewRecorder()
@@ -169,6 +602,8 @@ func TestHandlers(t *testing.T) {
 	assert.Equal(t, 95, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 	assert.True(t, r.DecayAfter.IsZero())
+	assert.Equal(t, "192.168.3.1", r.Object)
+	assert.Equal(t, "ip", r.Type)
 
 	// put violations
 	recorder = httptest.NewRecorder()
@@ -410,6 +845,23 @@ func TestViolationDecreaseLimit(t *testing.T) {
 }
 
 func TestExceptions(t *testing.T) {
+	assert.Nil(t, baseTest())
+	sruntime.cfg.Auth.DisableAuth = true
+	h := mwHandler(newRouter())
+
+	recorder := httptest.NewRecorder()
+	buf := "{\"object\": \"192.168.1.1\", \"type\": \"ip\", \"violation\": \"violation2\"}"
+	req := httptest.NewRequest("PUT", "/violations/type/ip/192.168.1.1", bytes.NewReader([]byte(buf)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	recorder = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/type/ip/192.168.1.1", nil)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+}
+
+func TestExceptionsLegacy(t *testing.T) {
 	assert.Nil(t, baseTest())
 	sruntime.cfg.Auth.DisableAuth = true
 	h := mwHandler(newRouter())

--- a/iprepd.yaml.sample
+++ b/iprepd.yaml.sample
@@ -33,18 +33,18 @@ auth:
     testuser: test
   # Set disableauth to true to turn of all authentication.
   disableauth: false
-# Configure violations that can be used when submitting a violation for an IP address
+# Configure violations that can be used when submitting a violation for an object
 # in this section.
 #
 # name: The name of a violation as would be submitted in a request to the API.
 ##
 # penalty: The number of points this violation will decrease the reputation for
-#          an IP address by.
+#          an object by.
 #
 # decreaselimit: The lower limit by which a given violation will decrease the reputation
-#                for a given IP address to. For example, if a violation has a penalty of 25
+#                for a given object to. For example, if a violation has a penalty of 25
 #                and a decreaselimit of 50, the first time this violation is applied to an
-#                IP address it will result in a reputation of 75. The second time, a reputation
+#                object it will result in a reputation of 75. The second time, a reputation
 #                score of 50. And subsequent violations will not lower the reputation further.
 violations:
   - name: test
@@ -53,18 +53,21 @@ violations:
   - name: test2
     penalty: 5
     decreaselimit: 25
-# The decay configuration controls how the reputation for an IP address recovers back to
+# The decay configuration controls how the reputation for an object recovers back to
 # 100 over time.
 #
-# points: The number of points added to the reputation of an IP address every interval.
+# points: The number of points added to the reputation of an object every interval.
 #
 # interval: How often the points are added to the reputation.
 decay:
   points: 1
   interval: 1s
 # Exceptions control IP address exceptions in iprepd. Any IP that matches an exception will
-# not be returned by ipred if it is requested (e.g., it will effectively have a reputation
+# not be returned by iprepd if it is requested (e.g., it will effectively have a reputation
 # score of 100). Useful for exempting internal IP addresses.
+#
+# Note the these exceptions only apply to requests for "ip" type objects, either through
+# the legacy API endpoints or object requests of type "ip".
 exceptions:
   # List any files that contain a list of CIDR subnets, one per line, that are loaded as
   # exceptions.

--- a/iprepd_test.go
+++ b/iprepd_test.go
@@ -46,7 +46,7 @@ func baseTest() error {
 	if err != nil {
 		return err
 	}
-	err = sruntime.redis.set(r.IP, buf, time.Hour*24).Err()
+	err = sruntime.redis.set(r.IP, buf, time.Hour*336).Err()
 	if err != nil {
 		return err
 	}

--- a/score.go
+++ b/score.go
@@ -83,7 +83,7 @@ func (r *Reputation) set() error {
 	if err != nil {
 		return err
 	}
-	return sruntime.redis.set(key, buf, time.Hour*24).Err()
+	return sruntime.redis.set(key, buf, time.Hour*336).Err()
 }
 
 func (r *Reputation) applyViolation(v string) (found bool, err error) {

--- a/score.go
+++ b/score.go
@@ -6,12 +6,24 @@ import (
 	"time"
 )
 
-// Reputation stores information related to the reputation of a given IP address
+// Reputation stores information related to the reputation of a given object
 type Reputation struct {
-	// IP is the IP address associated with the entry
-	IP string `json:"ip"`
+	// Object is the object associated with the reputation entry. For example
+	// if the type is "ip", object will be an IP address.
+	Object string `json:"object"`
 
-	// Reputation is the reputation score for the IP address, ranging from 0 to
+	// Type describes the type of object the reputation entry is for
+	Type string `json:"type"`
+
+	// IP is a legacy field that is associated with reputation requests for IP
+	// addresses, and is intended to maintain reverse compatibility.
+	//
+	// For responses from the API for IP address objects, Object and IP will
+	// be set to the same value. For reputation update requests for IP type
+	// objects, either can be used but Object will take precedence.
+	IP string `json:"ip,omitempty"`
+
+	// Reputation is the reputation score for the object, ranging from 0 to
 	// 100 where 100 indicates no violations have been applied to it.
 	Reputation int `json:"reputation"`
 
@@ -25,19 +37,36 @@ type Reputation struct {
 
 	// DecayAfter is used to temporarily stop reputation recovery until after the
 	// current time has passed the time indicated by DecayAfter. This can be used
-	// to for example enforce a mandatory minimum reputation decrease for an address
+	// to for example enforce a mandatory minimum reputation decrease for an object
 	// for a set period of time.
 	DecayAfter time.Time `json:"decayafter,omitempty"`
 }
 
-// Validate performs validation and normalization of a Reputation type.
+// Validate performs validation  of a Reputation type.
 func (r *Reputation) Validate() error {
-	// Assume we already have verification of the IP address through the handlers,
-	// so just check the reputation score here
+	if r.Object == "" {
+		return fmt.Errorf("reputation entry missing required field object")
+	}
+	if r.Type == "" {
+		return fmt.Errorf("reputation entry missing required field type")
+	}
+	if r.Type != "ip" && r.IP != "" {
+		return fmt.Errorf("ip field set and type is not ip")
+	}
 	if r.Reputation < 0 || r.Reputation > 100 {
 		return fmt.Errorf("invalid reputation score %v", r.Reputation)
 	}
 	return nil
+}
+
+func keyFromTypeAndValue(typestr string, valstr string) (string, error) {
+	if typestr == "" || valstr == "" {
+		return "", fmt.Errorf("type or value was not set")
+	}
+	if typestr == "ip" {
+		return valstr, nil
+	}
+	return typestr + " " + valstr, nil
 }
 
 func (r *Reputation) set() error {
@@ -50,7 +79,11 @@ func (r *Reputation) set() error {
 	if err != nil {
 		return err
 	}
-	return sruntime.redis.set(r.IP, buf, time.Hour*24).Err()
+	key, err := keyFromTypeAndValue(r.Type, r.Object)
+	if err != nil {
+		return err
+	}
+	return sruntime.redis.set(key, buf, time.Hour*24).Err()
 }
 
 func (r *Reputation) applyViolation(v string) (found bool, err error) {
@@ -71,7 +104,7 @@ func (r *Reputation) applyViolation(v string) (found bool, err error) {
 }
 
 func (r *Reputation) applyDecay() error {
-	// If DecayAfter is set and we haven't past the indicated time stamp yet
+	// If DecayAfter is set and we haven't past the indicated timestamp yet
 	// don't do anything with the current reputation value.
 	//
 	// If the value is set and we have passed the indicated point in time, replace
@@ -94,36 +127,66 @@ func (r *Reputation) applyDecay() error {
 	return nil
 }
 
-// Violation describes a violation penalty that can be applied to IP addresses.
+// Violation describes a violation penalty that can be applied to an object.
 type Violation struct {
 	// Name of violation as specified in iprepd cfg
 	Name string `json:"name"`
 
 	// Penalty is how many points a reputation will be decreased by if this
-	// violation is submitted for an IP
+	// violation is submitted for an object
 	Penalty int `json:"penalty"`
 
 	// DecreaseLimit is the lowest possible value this violation will decrease a
 	// reputation to. Since the same violation can be applied multiple times to
-	// the same IP, this can be used to place a lower bound on the total decrease.
+	// the same object, this can be used to place a lower bound on the total decrease.
 	DecreaseLimit int `json:"decreaselimit"`
 }
 
-func repGet(ipstr string) (ret Reputation, err error) {
-	buf, err := sruntime.redis.get(ipstr)
+func repGet(typestr string, valstr string) (ret Reputation, err error) {
+	var key string
+	key, err = keyFromTypeAndValue(typestr, valstr)
 	if err != nil {
 		return
 	}
+	buf, err := sruntime.redis.get(key)
+	if err != nil {
+		return
+	}
+
 	err = json.Unmarshal(buf, &ret)
 	if err != nil {
 		return
 	}
+
+	// Apply some compatibility fixups here for IP type requests
+	if typestr == "ip" {
+		if ret.Object == "" && ret.IP != "" {
+			// If we have an IP field set but object is unset, set the object field
+			// to IP as this is likely a legacy entry.
+			ret.Object = ret.IP
+		} else {
+			// Otherwise, just set the IP field to the value of the object field
+			// to maintain compatibility with older clients
+			ret.IP = ret.Object
+		}
+	}
+
+	// If the type field is unset in the stored entry, set it to the type that was
+	// used to make the request
+	if ret.Type == "" {
+		ret.Type = typestr
+	}
+
 	err = ret.applyDecay()
 	return
 }
 
-func repDelete(ipstr string) (err error) {
-	_, err = sruntime.redis.del(ipstr).Result()
+func repDelete(typestr string, valstr string) (err error) {
+	key, err := keyFromTypeAndValue(typestr, valstr)
+	if err != nil {
+		return err
+	}
+	_, err = sruntime.redis.del(key).Result()
 	return
 }
 
@@ -133,8 +196,10 @@ func repDump() (ret []Reputation, err error) {
 		return
 	}
 
-	for _, ip := range keys {
-		buf, err := sruntime.redis.get(ip)
+	// Collect and return all entries from the database; note that this is a raw dump
+	// and no compatibility fixups or any validation occurs on the returned entries.
+	for _, obj := range keys {
+		buf, err := sruntime.redis.get(obj)
 		if err != nil {
 			return ret, err
 		}

--- a/validators.go
+++ b/validators.go
@@ -1,0 +1,34 @@
+package iprepd
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+)
+
+var validators = map[string]func(string) error{
+	"ip":    validateTypeIp,
+	"email": validateTypeEmail,
+}
+
+func validateTypeIp(val string) error {
+	if net.ParseIP(val) == nil {
+		return fmt.Errorf("invalid ip format %v", val)
+	}
+	return nil
+}
+
+func validateTypeEmail(val string) error {
+	re := regexp.MustCompile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")
+	if !re.MatchString(val) {
+		return fmt.Errorf("invalid email format %v", val)
+	}
+	return nil
+}
+
+func validateType(t string, val string) error {
+	if fn, ok := validators[t]; ok {
+		return fn(val)
+	}
+	return fmt.Errorf("unknown type for validation %v", t)
+}


### PR DESCRIPTION
This PR adds support for tracking other types of objects besides just IP addresses (in this case, account address reputation tracking is being added).

New endpoints have been added that namespace by `/type/`, where type is currently `ip` or `email`.

Compatibility with older clients is maintained, and the legacy endpoints will still work for IP address based requests.

No fields have been removed from JSON responses from the API, however new fields are present that indicate the object and object type. For cases where the request is for an IP, `ip` and `object` will be set to the same value. Clients that do not handle fields in the JSON response that are unexpected will potentially be impacted.

This PR also bumps up the key expiry time and maximum recovery suppression interval.