### PR TITLE
Prevent log.Fatal() in exception.go

### DIFF
--- a/http.go
+++ b/http.go
@@ -361,6 +361,12 @@ func httpPutViolationsInner(w http.ResponseWriter, r *http.Request, typestr stri
 			return
 		}
 
+		if err = validateType(v.Type, v.Object); err != nil {
+			log.Warnf(err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
 		rep, err := repGet(typestr, v.Object)
 		if err == redis.Nil {
 			rep = Reputation{

--- a/http_test.go
+++ b/http_test.go
@@ -479,6 +479,24 @@ func TestHandlers(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	// put violations for malformed IP
+	recorder = httptest.NewRecorder()
+	buf2 = "[{\"object\": \"192auwgibcwai.1\", \"type\": \"ip\", \"violation\": \"violation1\"}," +
+		"{\"object\": \"192.168.5.1\", \"type\": \"ip\", \"violation\": \"violation2\"}]"
+	req = httptest.NewRequest("PUT", "/violations/type/ip", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	// put violations for malformed email
+	recorder = httptest.NewRecorder()
+	buf2 = "[{\"object\": \"rikermozilla.com\", \"type\": \"email\", \"violation\": \"violation1\"}," +
+		"{\"object\": \"troi@mozilla.com\", \"type\": \"email\", \"violation\": \"violation2\"}]"
+	req = httptest.NewRequest("PUT", "/violations/type/email", bytes.NewReader([]byte(buf2)))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 }
 
 func TestHandlersLegacy(t *testing.T) {

--- a/validators_test.go
+++ b/validators_test.go
@@ -1,0 +1,68 @@
+package iprepd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateType(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Type        string
+		Object      string
+		ExpectErr   bool
+		ExpectedErr error
+	}{
+		{
+			Name:      "test: validate good IP",
+			Type:      "ip",
+			Object:    "228.28.28.28",
+			ExpectErr: false,
+		},
+		{
+			Name:      "test: validate good Email",
+			Type:      "email",
+			Object:    "sstallone@mozilla.com",
+			ExpectErr: false,
+		},
+		{
+			Name:        "test: validate bad IP",
+			Type:        "ip",
+			Object:      "2assfa28.28",
+			ExpectErr:   true,
+			ExpectedErr: fmt.Errorf("invalid ip format %v", "2assfa28.28"),
+		},
+		{
+			Name:        "test: validate bad Email",
+			Type:        "email",
+			Object:      "not an email",
+			ExpectErr:   true,
+			ExpectedErr: fmt.Errorf("invalid email format %v", "not an email"),
+		},
+		{
+			Name:        "test: validate wrong type",
+			Type:        "email",
+			Object:      "228.28.28.28",
+			ExpectErr:   true,
+			ExpectedErr: fmt.Errorf("invalid email format %v", "228.28.28.28"),
+		},
+		{
+			Name:        "test: validate unknown type",
+			Type:        "some undefined type",
+			Object:      "228.28.28.28",
+			ExpectErr:   true,
+			ExpectedErr: fmt.Errorf("unknown type for validation %v", "some undefined type"),
+		},
+	}
+
+	for _, tst := range tests {
+		err := validateType(tst.Type, tst.Object)
+		if tst.ExpectErr {
+			assert.Equal(t, tst.ExpectedErr, err, tst.Name)
+		} else {
+			assert.Nil(t, err, tst.Name)
+		}
+	}
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1565467

This is my proposed solution to the issue -- it propagates the error to the caller as is the go way