### PR TITLE
Code Cleanup: use TypeX vars instead of hardcoded strings everywhere

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -115,7 +115,7 @@ func TestGetReputation(t *testing.T) {
 		{
 			Name:        "test: Good IP",
 			Object:      "192.168.0.1",
-			ObjectType:  typeIP,
+			ObjectType:  TypeIP,
 			ExpectErr:   false,
 			ExpectedRep: 50,
 			C:           goodClient,
@@ -123,7 +123,7 @@ func TestGetReputation(t *testing.T) {
 		{
 			Name:        "test: Good Email",
 			Object:      "usr@mozilla.com",
-			ObjectType:  typeEmail,
+			ObjectType:  TypeEmail,
 			ExpectErr:   false,
 			ExpectedRep: 50,
 			C:           goodClient,
@@ -131,7 +131,7 @@ func TestGetReputation(t *testing.T) {
 		// client side validation errors
 		{
 			Name:        "test: Missing Object",
-			ObjectType:  typeIP,
+			ObjectType:  TypeIP,
 			ExpectErr:   true,
 			ExpectedErr: errors.New(clientErrObjectEmpty),
 			C:           goodClient,
@@ -146,7 +146,7 @@ func TestGetReputation(t *testing.T) {
 		{
 			Name:        "test: Incorrect Object Type",
 			Object:      "8.8.8.8",
-			ObjectType:  typeEmail,
+			ObjectType:  TypeEmail,
 			ExpectErr:   true,
 			ExpectedErr: errors.New(clientErrBadType),
 			C:           goodClient,
@@ -154,7 +154,7 @@ func TestGetReputation(t *testing.T) {
 		{
 			Name:        "test: Bad Object Type",
 			Object:      "I am not an IP",
-			ObjectType:  typeIP,
+			ObjectType:  TypeIP,
 			ExpectErr:   true,
 			ExpectedErr: errors.New(clientErrBadType),
 			C:           goodClient,
@@ -163,7 +163,7 @@ func TestGetReputation(t *testing.T) {
 		{
 			Name:        "test: Non Existent Email",
 			Object:      "notinstore@mozilla.com",
-			ObjectType:  typeEmail,
+			ObjectType:  TypeEmail,
 			ExpectErr:   true,
 			ExpectedErr: fmt.Errorf("%s: %d", clientErrNon200, http.StatusNotFound),
 			C:           goodClient,
@@ -171,7 +171,7 @@ func TestGetReputation(t *testing.T) {
 		{
 			Name:        "test: Non Existent IP",
 			Object:      "8.8.8.8",
-			ObjectType:  typeIP,
+			ObjectType:  TypeIP,
 			ExpectErr:   true,
 			ExpectedErr: fmt.Errorf("%s: %d", clientErrNon200, http.StatusNotFound),
 			C:           goodClient,
@@ -179,7 +179,7 @@ func TestGetReputation(t *testing.T) {
 		{
 			Name:        "test: Unauthorized",
 			Object:      "192.168.0.1",
-			ObjectType:  typeIP,
+			ObjectType:  TypeIP,
 			ExpectErr:   true,
 			ExpectedErr: fmt.Errorf("%s: %d", clientErrNon200, http.StatusUnauthorized),
 			C:           badClient,
@@ -195,7 +195,7 @@ func TestGetReputation(t *testing.T) {
 			assert.Nil(t, err, tst.Name)
 			assert.Equal(t, tst.Object, rep.Object, tst.Name)
 			assert.Equal(t, tst.ObjectType, rep.Type, tst.Name)
-			if tst.ObjectType == typeIP {
+			if tst.ObjectType == TypeIP {
 				assert.Equal(t, tst.Object, rep.IP, tst.Name)
 			}
 			assert.Equal(t, rep.Reputation, tst.ExpectedRep)
@@ -226,7 +226,7 @@ func TestSetReputation(t *testing.T) {
 		{
 			Name: "test: Good IP",
 			R: &Reputation{
-				Type:       typeIP,
+				Type:       TypeIP,
 				Object:     "208.28.28.28",
 				Reputation: 10,
 			},
@@ -236,7 +236,7 @@ func TestSetReputation(t *testing.T) {
 		{
 			Name: "test: Good Email",
 			R: &Reputation{
-				Type:       typeEmail,
+				Type:       TypeEmail,
 				Object:     "sstallone@mozilla.com",
 				Reputation: 45,
 			},
@@ -253,7 +253,7 @@ func TestSetReputation(t *testing.T) {
 		{
 			Name: "test: Reputation No Object",
 			R: &Reputation{
-				Type:       typeEmail,
+				Type:       TypeEmail,
 				Reputation: 45,
 			},
 			ExpectErr:   true,
@@ -273,7 +273,7 @@ func TestSetReputation(t *testing.T) {
 		{
 			Name: "test: Bad IP",
 			R: &Reputation{
-				Type:       typeIP,
+				Type:       TypeIP,
 				Object:     "safhkenfo",
 				Reputation: 45,
 			},
@@ -284,7 +284,7 @@ func TestSetReputation(t *testing.T) {
 		{
 			Name: "test: Bad Email",
 			R: &Reputation{
-				Type:       typeEmail,
+				Type:       TypeEmail,
 				Object:     "safhkenfo",
 				Reputation: 45,
 			},
@@ -296,7 +296,7 @@ func TestSetReputation(t *testing.T) {
 		{
 			Name: "test: Unauthorized",
 			R: &Reputation{
-				Type:       typeIP,
+				Type:       TypeIP,
 				Object:     "208.28.28.28",
 				Reputation: 10,
 			},
@@ -337,35 +337,35 @@ func TestDeleteReputation(t *testing.T) {
 		{
 			Name:       "test: Good IP",
 			Object:     "192.168.0.1",
-			ObjectType: typeIP,
+			ObjectType: TypeIP,
 			ExpectErr:  false,
 			C:          goodClient,
 		},
 		{
 			Name:       "test: Good Email",
 			Object:     "usr@mozilla.com",
-			ObjectType: typeEmail,
+			ObjectType: TypeEmail,
 			ExpectErr:  false,
 			C:          goodClient,
 		},
 		{
 			Name:       "test: Non Existent Email",
 			Object:     "notinstore@mozilla.com",
-			ObjectType: typeEmail,
+			ObjectType: TypeEmail,
 			ExpectErr:  false,
 			C:          goodClient,
 		},
 		{
 			Name:       "test: Non Existent IP",
 			Object:     "8.8.8.8",
-			ObjectType: typeIP,
+			ObjectType: TypeIP,
 			ExpectErr:  false,
 			C:          goodClient,
 		},
 		// client side validation errors
 		{
 			Name:        "test: Missing Object",
-			ObjectType:  typeIP,
+			ObjectType:  TypeIP,
 			ExpectErr:   true,
 			ExpectedErr: errors.New(clientErrObjectEmpty),
 			C:           goodClient,
@@ -380,7 +380,7 @@ func TestDeleteReputation(t *testing.T) {
 		{
 			Name:        "test: Incorrect Object Type",
 			Object:      "8.8.8.8",
-			ObjectType:  typeEmail,
+			ObjectType:  TypeEmail,
 			ExpectErr:   true,
 			ExpectedErr: errors.New(clientErrBadType),
 			C:           goodClient,
@@ -388,7 +388,7 @@ func TestDeleteReputation(t *testing.T) {
 		{
 			Name:        "test: Bad Object Type",
 			Object:      "I am not an IP",
-			ObjectType:  typeIP,
+			ObjectType:  TypeIP,
 			ExpectErr:   true,
 			ExpectedErr: errors.New(clientErrBadType),
 			C:           goodClient,
@@ -397,7 +397,7 @@ func TestDeleteReputation(t *testing.T) {
 		{
 			Name:        "test: Unauthorized",
 			Object:      "192.168.0.1",
-			ObjectType:  typeIP,
+			ObjectType:  TypeIP,
 			ExpectErr:   true,
 			ExpectedErr: fmt.Errorf("%s: %d", clientErrNon200, http.StatusUnauthorized),
 			C:           badClient,
@@ -474,7 +474,7 @@ func TestApplyViolation(t *testing.T) {
 		{
 			Name: "test: Good IP",
 			VR: &ViolationRequest{
-				Type:      typeIP,
+				Type:      TypeIP,
 				Object:    "208.28.28.28",
 				Violation: "violation1",
 			},
@@ -484,7 +484,7 @@ func TestApplyViolation(t *testing.T) {
 		{
 			Name: "test: Good Email",
 			VR: &ViolationRequest{
-				Type:      typeEmail,
+				Type:      TypeEmail,
 				Object:    "sstallone@mozilla.com",
 				Violation: "violation1",
 			},
@@ -502,7 +502,7 @@ func TestApplyViolation(t *testing.T) {
 			Name:      "test: Violation Request No Object",
 			ExpectErr: true,
 			VR: &ViolationRequest{
-				Type:      typeEmail,
+				Type:      TypeEmail,
 				Violation: "violation1",
 			},
 			ExpectedErr: errors.New(clientErrObjectEmpty),
@@ -522,7 +522,7 @@ func TestApplyViolation(t *testing.T) {
 			Name:      "test: Violation Request No Violation",
 			ExpectErr: true,
 			VR: &ViolationRequest{
-				Type:   typeEmail,
+				Type:   TypeEmail,
 				Object: "sstallone@mozilla.com",
 			},
 			ExpectedErr: errors.New(clientErrViolationEmpty),
@@ -531,7 +531,7 @@ func TestApplyViolation(t *testing.T) {
 		{
 			Name: "test: Bad IP",
 			VR: &ViolationRequest{
-				Type:      typeIP,
+				Type:      TypeIP,
 				Object:    "I'm not an IP",
 				Violation: "violation1",
 			},
@@ -542,7 +542,7 @@ func TestApplyViolation(t *testing.T) {
 		{
 			Name: "test: Bad Email",
 			VR: &ViolationRequest{
-				Type:      typeEmail,
+				Type:      TypeEmail,
 				Object:    "I'm not an email",
 				Violation: "violation1",
 			},
@@ -554,7 +554,7 @@ func TestApplyViolation(t *testing.T) {
 		{
 			Name: "test: Unauthorized",
 			VR: &ViolationRequest{
-				Type:      typeIP,
+				Type:      TypeIP,
 				Object:    "208.28.28.28",
 				Violation: "violation1",
 			},
@@ -594,7 +594,7 @@ func TestBatchApplyViolations(t *testing.T) {
 		//	positive tests
 		{
 			Name: "test: Good IPs",
-			Type: typeIP,
+			Type: TypeIP,
 			VRS: []ViolationRequest{
 				{
 					Object:    "208.28.28.25",
@@ -614,7 +614,7 @@ func TestBatchApplyViolations(t *testing.T) {
 		},
 		{
 			Name: "test: Good Emails",
-			Type: typeEmail,
+			Type: TypeEmail,
 			VRS: []ViolationRequest{
 				{
 					Object:    "lfine@mozilla.com",
@@ -635,14 +635,14 @@ func TestBatchApplyViolations(t *testing.T) {
 		// client side validation errors
 		{
 			Name:      "test: Empty Slice",
-			Type:      typeIP,
+			Type:      TypeIP,
 			VRS:       []ViolationRequest{},
 			ExpectErr: false,
 			C:         goodClient,
 		},
 		{
 			Name:      "test: Nil Slice",
-			Type:      typeIP,
+			Type:      TypeIP,
 			ExpectErr: false,
 			C:         goodClient,
 		},
@@ -655,7 +655,7 @@ func TestBatchApplyViolations(t *testing.T) {
 		// server error propagation
 		{
 			Name: "test: Malformed IP in Violation Request",
-			Type: typeIP,
+			Type: TypeIP,
 			VRS: []ViolationRequest{
 				{
 					Object:    "asd8.28.26",
@@ -672,10 +672,10 @@ func TestBatchApplyViolations(t *testing.T) {
 		},
 		{
 			Name: "test: Unauthorized",
-			Type: typeIP,
+			Type: TypeIP,
 			VRS: []ViolationRequest{
 				{
-					Type:      typeIP,
+					Type:      TypeIP,
 					Object:    "208.28.28.28",
 					Violation: "violation1",
 				},

--- a/http.go
+++ b/http.go
@@ -37,14 +37,17 @@ type ViolationRequest struct {
 }
 
 const (
-	typeIP    = "ip"
-	typeEmail = "email"
+	// TypeIP is the object type for IP addresses
+	TypeIP = "ip"
+
+	// TypeEmail is the object type for email addresses
+	TypeEmail = "email"
 )
 
 // Fixup is used to convert legacy format violations
 func (v *ViolationRequest) Fixup(typestr string) {
 	// Only apply fixup to ip type requests
-	if typestr != "ip" {
+	if typestr != TypeIP {
 		return
 	}
 	// If the type field is not set, set it to the type specified in the request
@@ -130,7 +133,7 @@ func startAPI() error {
 func wrapLegacyIPRequest(rf func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		m := mux.Vars(r)
-		m["type"] = "ip"
+		m["type"] = TypeIP
 		mux.SetURLVars(r, m)
 		rf(w, r)
 	}
@@ -219,7 +222,7 @@ func httpGetReputation(w http.ResponseWriter, r *http.Request) {
 	}
 	// If the request is for an IP type object, consult the exception list. Currently
 	// exceptions only apply to IP objects.
-	if typestr == "ip" {
+	if typestr == TypeIP {
 		exc, err := isException(valstr)
 		if err != nil {
 			log.Errorf("Error looking up exception: %s", err)
@@ -286,7 +289,7 @@ func httpPutReputation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	exc := false
-	if rep.Type == "ip" {
+	if rep.Type == TypeIP {
 		exc, err = isException(rep.Object)
 		if err != nil {
 			log.Errorf("Error looking up exception: %s", err)
@@ -436,7 +439,7 @@ func httpPutViolationsInner(w http.ResponseWriter, r *http.Request, typestr stri
 			return
 		}
 		exc := false
-		if rep.Type == "ip" {
+		if rep.Type == TypeIP {
 			exc, err = isException(rep.Object)
 			if err != nil {
 				log.Errorf("Error looking up exception: %s", err)

--- a/http_test.go
+++ b/http_test.go
@@ -62,7 +62,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.0.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 50, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 
@@ -78,7 +78,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "254.254.254.254", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 40, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 	// IP field should also be set
@@ -137,7 +137,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.2.20", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 25, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 
@@ -162,7 +162,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "riker@mozilla.com", r.Object)
-	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, TypeEmail, r.Type)
 	assert.Equal(t, 50, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 
@@ -200,19 +200,19 @@ func TestHandlers(t *testing.T) {
 		if rep.Object == "192.168.2.20" {
 			c++
 			assert.Equal(t, "192.168.2.20", rep.Object)
-			assert.Equal(t, "ip", rep.Type)
+			assert.Equal(t, TypeIP, rep.Type)
 			assert.Equal(t, 25, rep.Reputation)
 		}
 		if rep.Object == "192.168.0.1" {
 			c++
 			assert.Equal(t, "192.168.0.1", rep.Object)
-			assert.Equal(t, "ip", rep.Type)
+			assert.Equal(t, TypeIP, rep.Type)
 			assert.Equal(t, 50, rep.Reputation)
 		}
 		if rep.Object == "riker@mozilla.com" {
 			c++
 			assert.Equal(t, "riker@mozilla.com", rep.Object)
-			assert.Equal(t, "email", rep.Type)
+			assert.Equal(t, TypeEmail, rep.Type)
 			assert.Equal(t, 50, rep.Reputation)
 		}
 		if rep.IP == "254.254.254.254" {
@@ -256,7 +256,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "janeway@mozilla.com", r.Object)
-	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, TypeEmail, r.Type)
 	assert.Equal(t, 50, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 	recorder = httptest.NewRecorder()
@@ -285,7 +285,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.3.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 95, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 	assert.True(t, r.DecayAfter.IsZero())
@@ -307,7 +307,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "riker@mozilla.com", r.Object)
-	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, TypeEmail, r.Type)
 	assert.Equal(t, 45, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 	assert.True(t, r.DecayAfter.IsZero())
@@ -330,7 +330,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.4.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 95, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 	recorder = httptest.NewRecorder()
@@ -343,7 +343,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.5.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 50, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 
@@ -365,7 +365,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "riker@mozilla.com", r.Object)
-	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, TypeEmail, r.Type)
 	assert.Equal(t, 40, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 	recorder = httptest.NewRecorder()
@@ -378,7 +378,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "troi@mozilla.com", r.Object)
-	assert.Equal(t, "email", r.Type)
+	assert.Equal(t, TypeEmail, r.Type)
 	assert.Equal(t, 50, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 
@@ -401,7 +401,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.6.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 95, r.Reputation)
 	assert.InDelta(t, dt.Unix(), r.DecayAfter.Unix(), 5)
 
@@ -422,7 +422,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.6.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 90, r.Reputation)
 	assert.InDelta(t, dt.Unix(), r.DecayAfter.Unix(), 5)
 
@@ -444,7 +444,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.6.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 85, r.Reputation)
 	assert.InDelta(t, dt.Unix(), r.DecayAfter.Unix(), 5)
 
@@ -467,7 +467,7 @@ func TestHandlers(t *testing.T) {
 	err = json.Unmarshal(buf, &r)
 	assert.Nil(t, err)
 	assert.Equal(t, "192.168.6.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 	assert.Equal(t, 85, r.Reputation)
 	assert.InDelta(t, dt.Unix(), r.DecayAfter.Unix(), 5)
 
@@ -522,7 +522,7 @@ func TestHandlersLegacy(t *testing.T) {
 	// The object and type fields should also be set on request to the legacy endpoint
 	// here
 	assert.Equal(t, "192.168.0.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 
 	// request reputation for a stored legacy format entry
 	recorder = httptest.NewRecorder()
@@ -541,7 +541,7 @@ func TestHandlersLegacy(t *testing.T) {
 	// The object and type fields should also be set on request to the legacy endpoint
 	// here
 	assert.Equal(t, "254.254.254.254", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 
 	// request reputation for an unknown ip
 	recorder = httptest.NewRecorder()
@@ -580,7 +580,7 @@ func TestHandlersLegacy(t *testing.T) {
 	assert.Equal(t, 25, r.Reputation)
 	assert.Equal(t, false, r.Reviewed)
 	assert.Equal(t, "192.168.2.20", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 
 	// try to store invalid reputation score
 	recorder = httptest.NewRecorder()
@@ -621,7 +621,7 @@ func TestHandlersLegacy(t *testing.T) {
 	assert.Equal(t, false, r.Reviewed)
 	assert.True(t, r.DecayAfter.IsZero())
 	assert.Equal(t, "192.168.3.1", r.Object)
-	assert.Equal(t, "ip", r.Type)
+	assert.Equal(t, TypeIP, r.Type)
 
 	// put violations
 	recorder = httptest.NewRecorder()

--- a/iprepd_test.go
+++ b/iprepd_test.go
@@ -36,7 +36,7 @@ func baseTest() error {
 	sruntime.versionResponse = vrBytes
 	r := Reputation{
 		Object:     "192.168.0.1",
-		Type:       "ip",
+		Type:       TypeIP,
 		Reputation: 50,
 	}
 	err = r.set()
@@ -45,7 +45,7 @@ func baseTest() error {
 	}
 	r = Reputation{
 		Object:     "10.0.0.1",
-		Type:       "ip",
+		Type:       TypeIP,
 		Reputation: 25,
 	}
 	err = r.set()
@@ -54,7 +54,7 @@ func baseTest() error {
 	}
 	r = Reputation{
 		Object:     "usr@mozilla.com",
-		Type:       "email",
+		Type:       TypeEmail,
 		Reputation: 50,
 	}
 	err = r.set()

--- a/score.go
+++ b/score.go
@@ -50,7 +50,7 @@ func (r *Reputation) Validate() error {
 	if r.Type == "" {
 		return fmt.Errorf("reputation entry missing required field type")
 	}
-	if r.Type != "ip" && r.IP != "" {
+	if r.Type != TypeIP && r.IP != "" {
 		return fmt.Errorf("ip field set and type is not ip")
 	}
 	if r.Reputation < 0 || r.Reputation > 100 {
@@ -63,7 +63,7 @@ func keyFromTypeAndValue(typestr string, valstr string) (string, error) {
 	if typestr == "" || valstr == "" {
 		return "", fmt.Errorf("type or value was not set")
 	}
-	if typestr == "ip" {
+	if typestr == TypeIP {
 		return valstr, nil
 	}
 	return typestr + " " + valstr, nil
@@ -159,7 +159,7 @@ func repGet(typestr string, valstr string) (ret Reputation, err error) {
 	}
 
 	// Apply some compatibility fixups here for IP type requests
-	if typestr == "ip" {
+	if typestr == TypeIP {
 		if ret.Object == "" && ret.IP != "" {
 			// If we have an IP field set but object is unset, set the object field
 			// to IP as this is likely a legacy entry.

--- a/validators.go
+++ b/validators.go
@@ -7,8 +7,8 @@ import (
 )
 
 var validators = map[string]func(string) error{
-	"ip":    validateTypeIP,
-	"email": validateTypeEmail,
+	TypeIP:    validateTypeIP,
+	TypeEmail: validateTypeEmail,
 }
 
 func validateTypeIP(val string) error {

--- a/validators_test.go
+++ b/validators_test.go
@@ -17,33 +17,33 @@ func TestValidateType(t *testing.T) {
 	}{
 		{
 			Name:      "test: validate good IP",
-			Type:      "ip",
+			Type:      TypeIP,
 			Object:    "228.28.28.28",
 			ExpectErr: false,
 		},
 		{
 			Name:      "test: validate good Email",
-			Type:      "email",
+			Type:      TypeEmail,
 			Object:    "sstallone@mozilla.com",
 			ExpectErr: false,
 		},
 		{
 			Name:        "test: validate bad IP",
-			Type:        "ip",
+			Type:        TypeIP,
 			Object:      "2assfa28.28",
 			ExpectErr:   true,
 			ExpectedErr: fmt.Errorf("invalid ip format %v", "2assfa28.28"),
 		},
 		{
 			Name:        "test: validate bad Email",
-			Type:        "email",
+			Type:        TypeEmail,
 			Object:      "not an email",
 			ExpectErr:   true,
 			ExpectedErr: fmt.Errorf("invalid email format %v", "not an email"),
 		},
 		{
 			Name:        "test: validate wrong type",
-			Type:        "email",
+			Type:        TypeEmail,
 			Object:      "228.28.28.28",
 			ExpectErr:   true,
 			ExpectedErr: fmt.Errorf("invalid email format %v", "228.28.28.28"),


### PR DESCRIPTION
* Exported TypeEmail and TypeIP for use by clients
* Using TypeEmail and TypeIP everywhere instead of "ip" and "email"

Clean code == happiness

![image](https://user-images.githubusercontent.com/16856511/61481844-ff298d80-a94d-11e9-802e-b3bf41990a3c.png)
