### PR TITLE
Add IPv6 support, remove legacy endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ names or email addresses.
 The daemon provides an HTTP API for requests, and uses a Redis server as the backend storage
 mechanism. Multiple instances of the daemon can be deployed using the same Redis backend.
 
+__Note__: Support for legacy endpoints, such as `GET /127.0.0.1` has been discontinued. Typed
+endpoints must now be used. For more information see the API documentation below. Some minor
+modification to client code is required to convert from the old endpoints.
+
 ## Configuration
 
 Configuration is done through the configuration file, by default `./iprepd.yaml`. The location
@@ -186,104 +190,6 @@ Service heartbeat endpoint.
 #### GET /\_\_version\_\_
 
 Return version data.
-
-### Legacy endpoints
-
-The initial version of iprepd focused purely on reputation management for IP addresses.
-Requests to the legacy endpoints deal only with IP addresses, and are intended to maintain
-compatibility with older clients.
-
-Requests to the legacy endpoints are essentially the same thing as making a request to the
-standard endpoints with a type set to `ip`.
-
-#### GET /10.0.0.1
-
-Request the reputation for an IP address. Responds with 200 and a JSON document describing the
-reputation if found. Responds with a 404 if the IP address is unknown to iprepd, or is in the
-exceptions list.
-
-The response body may include a `decayafter` element if the reputation for the address was changed
-with a recovery suppression applied. If the timestamp is present, it indicates the time after which
-the reputation for the address will begin to recover.
-
-##### Response body
-
-```json
-{
-	"ip": "10.0.0.1",
-	"reputation": 75,
-	"reviewed": false,
-	"lastupdated": "2018-04-23T18:25:43.511Z"
-}
-```
-
-#### DELETE /10.0.0.1
-
-Deletes the reputation entry for the IP address.
-
-#### PUT /10.0.0.1
-
-Sets a reputation score for the IP address. A reputation JSON document must be provided with the
-request body. The `reputation` field must be provided in the document. The reviewed field
-can be included and set to true to toggle the reviewed field for a given reputation entry.
-
-Note that if the reputation decays back to 100, if the reviewed field is set on the entry it will
-toggle back to false.
-
-The reputation will begin to decay back to 100 immediately for the address based on the decay
-settings in the configuration file. If it is desired that the reputation should not decay for a
-period of time, the `decayafter` field can be set with a timestamp to indicate when the reputation
-decay logic should begin to be applied for the entry.
-
-##### Request body
-
-```json
-{
-	"ip": "10.0.0.1",
-	"reputation": 75
-}
-```
-
-#### PUT /violations/10.0.0.1
-
-Applies a violation penalty to an IP address.
-
-If an unknown violation penalty is submitted, this endpoint will still return 200, but the
-error will be logged.
-
-If desired, `suppress_recovery` can be included in the request body and set to an integer which
-indicates the number of seconds that must elapse before the reputation for this entry will begin
-to decay back to 100. If this setting is not included, the reputation will begin to decay
-immediately. If the violation is being applied to an existing entry, the `suppress_recovery` field
-will only be applied if the existing entry has no current recovery suppression, or the specified
-recovery suppression time frame would result in a time in the future beyond which the entry
-currently has. If `suppress_recovery` is included it must be less than `259200` (72 hours).
-
-##### Request body
-
-```json
-{
-	"ip": "10.0.0.1",
-	"violation": "violation1"
-}
-```
-
-#### PUT /violations
-
-Applies a violation penalty to a multiple IP addresses.
-
-If an unknown violation penalty is submitted, this endpoint will still return 200, but the
-error will be logged.
-
-##### Request body
-
-```json
-[
-	{"ip": "10.0.0.1", "violation": "violation1"},
-	{"ip": "10.0.0.2", "violation": "violation1"},
-	{"ip": "10.0.0.3", "violation": "violation2"}
-]
-```
 
 ## Acknowledgements
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -17,33 +17,33 @@ func TestAuth(t *testing.T) {
 
 	// auth'd endpoint, should fail
 	recorder := httptest.NewRecorder()
-	h.ServeHTTP(recorder, httptest.NewRequest("GET", "/192.168.0.1", nil))
+	h.ServeHTTP(recorder, httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil))
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 
 	// valid api key
 	recorder = httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req := httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	req.Header.Set("Authorization", "APIKey key1")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusOK, recorder.Code)
 
 	// invalid api key
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	req.Header.Set("Authorization", "APIKey key1invalid")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 
 	// zero length api key
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	req.Header.Set("Authorization", "APIKey ")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 
 	// valid Read-Only API key for write-not-required endpoint
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	req.Header.Set("Authorization", "APIKey rokey1")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusOK, recorder.Code)
@@ -51,7 +51,7 @@ func TestAuth(t *testing.T) {
 	// valid Read-Only API key for write-required endpoint
 	recorder = httptest.NewRecorder()
 	buf := "{\"ip\": \"192.168.0.1\", \"reputation\": 50}"
-	req = httptest.NewRequest("PUT", "/192.168.0.1", bytes.NewReader([]byte(buf)))
+	req = httptest.NewRequest("PUT", "/type/ip/192.168.0.1", bytes.NewReader([]byte(buf)))
 	req.Header.Set("Authorization", "APIKey rokey1")
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(recorder, req)
@@ -59,7 +59,7 @@ func TestAuth(t *testing.T) {
 
 	// valid hawk header
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	auth := hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "root",
 		Key:  "toor",
@@ -71,7 +71,7 @@ func TestAuth(t *testing.T) {
 
 	// valid Read-Only hawk for a write-not-required endpoint
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "roroot",
 		Key:  "rotoor",
@@ -84,7 +84,7 @@ func TestAuth(t *testing.T) {
 	// valid Read-Only hawk for a write-required endpoint
 	recorder = httptest.NewRecorder()
 	buf = "{\"ip\": \"192.168.0.1\", \"reputation\": 50}"
-	req = httptest.NewRequest("PUT", "/192.168.0.1", bytes.NewReader([]byte(buf)))
+	req = httptest.NewRequest("PUT", "/type/ip/192.168.0.1", bytes.NewReader([]byte(buf)))
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "roroot",
 		Key:  "rotoor",
@@ -100,7 +100,7 @@ func TestAuth(t *testing.T) {
 
 	// invalid hawk id
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "invalid",
 		Key:  "toor",
@@ -112,7 +112,7 @@ func TestAuth(t *testing.T) {
 
 	// invalid hawk secret
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "root",
 		Key:  "invalid",
@@ -125,7 +125,7 @@ func TestAuth(t *testing.T) {
 	// valid hawk credentials with a content-type set but no request body on GET,
 	// verify the request is rejected
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "root",
 		Key:  "toor",
@@ -139,7 +139,7 @@ func TestAuth(t *testing.T) {
 	// valid hawk put with a request body
 	recorder = httptest.NewRecorder()
 	buf = "{\"ip\": \"192.168.0.1\", \"reputation\": 50}"
-	req = httptest.NewRequest("PUT", "/192.168.0.1", bytes.NewReader([]byte(buf)))
+	req = httptest.NewRequest("PUT", "/type/ip/192.168.0.1", bytes.NewReader([]byte(buf)))
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "root",
 		Key:  "toor",
@@ -155,7 +155,7 @@ func TestAuth(t *testing.T) {
 
 	// valid hawk creds in a put with a request body, but missing a content-type
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("PUT", "/192.168.0.1", bytes.NewReader([]byte(buf)))
+	req = httptest.NewRequest("PUT", "/type/ip/192.168.0.1", bytes.NewReader([]byte(buf)))
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "root",
 		Key:  "toor",
@@ -170,7 +170,7 @@ func TestAuth(t *testing.T) {
 
 	// valid hawk creds in a put with a request body, missing a payload hash
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("PUT", "/192.168.0.1", bytes.NewReader([]byte(buf)))
+	req = httptest.NewRequest("PUT", "/type/ip/192.168.0.1", bytes.NewReader([]byte(buf)))
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "root",
 		Key:  "toor",
@@ -183,21 +183,21 @@ func TestAuth(t *testing.T) {
 
 	// invalid hawk header
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	req.Header.Set("Authorization", "Hawk invalid")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 
 	// zero length hawk header
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	req.Header.Set("Authorization", "Hawk ")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
 
 	// empty authorization header
 	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/192.168.0.1", nil)
+	req = httptest.NewRequest("GET", "/type/ip/192.168.0.1", nil)
 	req.Header.Set("Authorization", " ")
 	h.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusUnauthorized, recorder.Code)

--- a/auth_test.go
+++ b/auth_test.go
@@ -50,7 +50,7 @@ func TestAuth(t *testing.T) {
 
 	// valid Read-Only API key for write-required endpoint
 	recorder = httptest.NewRecorder()
-	buf := "{\"ip\": \"192.168.0.1\", \"reputation\": 50}"
+	buf := "{\"object\": \"192.168.0.1\", \"type\": \"ip\", \"reputation\": 50}"
 	req = httptest.NewRequest("PUT", "/type/ip/192.168.0.1", bytes.NewReader([]byte(buf)))
 	req.Header.Set("Authorization", "APIKey rokey1")
 	req.Header.Set("Content-Type", "application/json")
@@ -83,7 +83,7 @@ func TestAuth(t *testing.T) {
 
 	// valid Read-Only hawk for a write-required endpoint
 	recorder = httptest.NewRecorder()
-	buf = "{\"ip\": \"192.168.0.1\", \"reputation\": 50}"
+	buf = "{\"object\": \"192.168.0.1\", \"type\": \"ip\", \"reputation\": 50}"
 	req = httptest.NewRequest("PUT", "/type/ip/192.168.0.1", bytes.NewReader([]byte(buf)))
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "roroot",
@@ -138,7 +138,7 @@ func TestAuth(t *testing.T) {
 
 	// valid hawk put with a request body
 	recorder = httptest.NewRecorder()
-	buf = "{\"ip\": \"192.168.0.1\", \"reputation\": 50}"
+	buf = "{\"object\": \"192.168.0.1\", \"type\": \"ip\", \"reputation\": 50}"
 	req = httptest.NewRequest("PUT", "/type/ip/192.168.0.1", bytes.NewReader([]byte(buf)))
 	auth = hawk.NewRequestAuth(req, &hawk.Credentials{
 		ID:   "root",

--- a/client_test.go
+++ b/client_test.go
@@ -195,9 +195,6 @@ func TestGetReputation(t *testing.T) {
 			assert.Nil(t, err, tst.Name)
 			assert.Equal(t, tst.Object, rep.Object, tst.Name)
 			assert.Equal(t, tst.ObjectType, rep.Type, tst.Name)
-			if tst.ObjectType == TypeIP {
-				assert.Equal(t, tst.Object, rep.IP, tst.Name)
-			}
 			assert.Equal(t, rep.Reputation, tst.ExpectedRep)
 			assert.Equal(t, false, rep.Reviewed, tst.Name)
 			assert.Equal(t, "0001-01-01 00:00:00 +0000 UTC", rep.DecayAfter.String(), tst.Name)

--- a/exception.go
+++ b/exception.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -97,6 +98,12 @@ func loadExceptions() {
 }
 
 func isException(ipstr string) (bool, error) {
+	// XXX See if the input contains both a . and a : character (IPv4 mapped IPv6 address
+	// using dot notation). If so, don't run a check. These addresses are not currently
+	// supported in the exception code.
+	if strings.Contains(ipstr, ":") && strings.Contains(ipstr, ".") {
+		return false, nil
+	}
 	treeLock.Lock()
 	_, f, err := activeTree.GetByString(ipstr)
 	treeLock.Unlock()

--- a/iprepd.go
+++ b/iprepd.go
@@ -38,6 +38,7 @@ type serverCfg struct {
 		ROHawk      map[string]string
 		ROAPIKey    map[string]string
 	}
+	IP6Prefix  int
 	Violations []Violation
 	Decay      struct {
 		Points   int
@@ -68,6 +69,9 @@ func (cfg *serverCfg) validate() error {
 	}
 	if cfg.Redis.MinIdleConn == 0 {
 		cfg.Redis.MinIdleConn = 20
+	}
+	if cfg.IP6Prefix == 0 {
+		cfg.IP6Prefix = 64
 	}
 	return nil
 }

--- a/iprepd.yaml.sample
+++ b/iprepd.yaml.sample
@@ -39,6 +39,10 @@ auth:
     rotestuser: rotest
   # Set disableauth to true to turn of all authentication.
   disableauth: false
+# The prefix to use with IPv6 address reputation updates or lookups. For example, if a reputation
+# is set on an IPv6 address it will apply to all addresses within the prefix. We default to /64,
+# which is an end-user allocation size.
+ip6prefix: 64
 # Configure violations that can be used when submitting a violation for an object
 # in this section.
 #

--- a/iprepd.yaml.sample
+++ b/iprepd.yaml.sample
@@ -42,6 +42,9 @@ auth:
 # The prefix to use with IPv6 address reputation updates or lookups. For example, if a reputation
 # is set on an IPv6 address it will apply to all addresses within the prefix. We default to /64,
 # which is an end-user allocation size.
+#
+# Note that changing this configuration value will invalidate all existing IPv6 reputation entries
+# in the cache.
 ip6prefix: 64
 # Configure violations that can be used when submitting a violation for an object
 # in this section.

--- a/iprepd_test.go
+++ b/iprepd_test.go
@@ -53,26 +53,20 @@ func baseTest() error {
 		return err
 	}
 	r = Reputation{
-		Object:     "usr@mozilla.com",
-		Type:       TypeEmail,
+		Object:     "2001:db8:a0b:12f0::1",
+		Type:       TypeIP,
 		Reputation: 50,
 	}
 	err = r.set()
 	if err != nil {
 		return err
 	}
-	// Add a legacy format reputation entry for testing, needs to be added
-	// manually to bypass the insertion validator
 	r = Reputation{
-		IP:          "254.254.254.254",
-		Reputation:  40,
-		LastUpdated: time.Now().UTC(),
+		Object:     "usr@mozilla.com",
+		Type:       TypeEmail,
+		Reputation: 50,
 	}
-	buf, err := json.Marshal(r)
-	if err != nil {
-		return err
-	}
-	err = sruntime.redis.set(r.IP, buf, time.Hour*336).Err()
+	err = r.set()
 	if err != nil {
 		return err
 	}
@@ -122,6 +116,7 @@ func TestMain(m *testing.M) {
 		{"violation2", 50, 50},
 		{"violation3", 0, 0},
 	}
+	sruntime.cfg.IP6Prefix = 64
 	loadExceptions()
 	os.Exit(m.Run())
 }

--- a/score.go
+++ b/score.go
@@ -18,14 +18,6 @@ type Reputation struct {
 	// Type describes the type of object the reputation entry is for
 	Type string `json:"type"`
 
-	// IP is a legacy field that is associated with reputation requests for IP
-	// addresses, and is intended to maintain reverse compatibility.
-	//
-	// For responses from the API for IP address objects, Object and IP will
-	// be set to the same value. For reputation update requests for IP type
-	// objects, either can be used but Object will take precedence.
-	IP string `json:"ip,omitempty"`
-
 	// Reputation is the reputation score for the object, ranging from 0 to
 	// 100 where 100 indicates no violations have been applied to it.
 	Reputation int `json:"reputation"`
@@ -52,9 +44,6 @@ func (r *Reputation) Validate() error {
 	}
 	if r.Type == "" {
 		return fmt.Errorf("reputation entry missing required field type")
-	}
-	if r.Type != TypeIP && r.IP != "" {
-		return fmt.Errorf("ip field set and type is not ip")
 	}
 	if r.Reputation < 0 || r.Reputation > 100 {
 		return fmt.Errorf("invalid reputation score %v", r.Reputation)
@@ -203,19 +192,6 @@ func repGet(typestr string, valstr string) (ret Reputation, err error) {
 	err = json.Unmarshal(buf, &ret)
 	if err != nil {
 		return
-	}
-
-	// Apply some compatibility fixups here for IP type requests
-	if typestr == TypeIP {
-		if ret.Object == "" && ret.IP != "" {
-			// If we have an IP field set but object is unset, set the object field
-			// to IP as this is likely a legacy entry.
-			ret.Object = ret.IP
-		} else {
-			// Otherwise, just set the IP field to the value of the object field
-			// to maintain compatibility with older clients
-			ret.IP = ret.Object
-		}
 	}
 
 	// If the type field is unset in the stored entry, set it to the type that was


### PR DESCRIPTION
Adds support for processing IPv6 addresses. By default, submitted addresses are collapsed by default to a bit width corresponding to the end-user address allocation size.

Also removes support for the legacy untyped endpoints and adjusts all tests.

Closes #35 
Closes #37 

There are some efficiencies that can be added here to avoid address string conversion multiple times for the same request, but I am leaving those out of this PR for now.
