### PR TITLE
Add decay within dump handler

### DIFF
--- a/score.go
+++ b/score.go
@@ -231,6 +231,12 @@ func repDump() (ret []Reputation, err error) {
 		if err != nil {
 			return ret, err
 		}
+
+		err = reputation.applyDecay()
+		if err != nil {
+			return ret, err
+		}
+
 		ret = append(ret, reputation)
 	}
 


### PR DESCRIPTION
This change applies decay for every reputation value within the `/dump` handler before returning.

I've tested this manually, but sadly I don't see any unit or integration tests that test actual decaying. I'm definitely open to adding that but didn't want to on the first pass.

cc: @pwnbus